### PR TITLE
Use the npm package `two`

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
   "scripts": {
     "build": "rm -r dist & tsc",
     "build:watch": "tsc --watch"
+  },
+  "dependencies": {
+    "two": "^1.0.7"
   }
 }

--- a/src/util/isTwo.ts
+++ b/src/util/isTwo.ts
@@ -1,3 +1,5 @@
+import two from "two"
+
 export const isTwo = (num: number) => {
-  return num === 2;
-};
+  return num === two()
+}


### PR DESCRIPTION
Instead of using the barebones value of `2`, `isTwo` should use the `two` npm package